### PR TITLE
Substitute metpy functions 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,11 +3,9 @@ name: CI
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push or pull request events
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
     # Run the job for different versions of python
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
 

--- a/fronts.py
+++ b/fronts.py
@@ -54,7 +54,7 @@ def wetbulb(ta, hus, plev, steps=100, ta_units=None):
 
 
 def dewpoint(ta, hus, plev, ta_units=None):
-    # calculates depoint temperature from pressure-level data
+    # calculates dewpoint temperature from pressure-level data
     # Inputs: ta - temperature field (xarray)
     #         hus - specific humidity field (xarray)
     #         plev - the level of the data (in hPa, scalar)

--- a/test_front.py
+++ b/test_front.py
@@ -31,7 +31,7 @@ def test_dewpoint():
 
     test_data = xr.open_dataset('tests/front_test.nc')#.metpy.quantify()
 
-    dp = dewpoint_from_specific_humidity(test_data.level, test_data.t, test_data.q)
+    dp = dewpoint_from_specific_humidity(test_data.level, test_data.t, test_data.q) * units.degK
 
     print(dp)
     dp2 = fronts.dewpoint(test_data.t, test_data.q, test_data.level, ta_units=str(test_data.t.metpy.units)) * units.degK

--- a/test_front.py
+++ b/test_front.py
@@ -28,24 +28,26 @@ def test_front_detection():
         assert frontdata == sample
 
 def test_dewpoint():
+    """
+    Test the metpy and internal dewpoint routines are consistent
+    """
 
-    test_data = xr.open_dataset('tests/front_test.nc')#.metpy.quantify()
+    test_data = xr.open_dataset('tests/front_test.nc')
 
-    dp = dewpoint_from_specific_humidity(test_data.level, test_data.t, test_data.q) * units.degK
-
-    print(dp)
+    dp = dewpoint_from_specific_humidity(test_data.level, test_data.t, test_data.q).metpy.convert_units('degK')
     dp2 = fronts.dewpoint(test_data.t, test_data.q, test_data.level, ta_units=str(test_data.t.metpy.units)) * units.degK
 
-    # import pdb; pdb.set_trace()
     assert_allclose(dp, dp2)
 
 def test_wetbulb():
+    """
+    Test the metpy and internal wetbulb routines are consistent
+    """
 
     test_data = xr.open_dataset('tests/front_test.nc').metpy.quantify()
 
-    dp = dewpoint_from_specific_humidity(test_data.level, test_data.t, test_data.q)
+    dp = dewpoint_from_specific_humidity(test_data.level, test_data.t, test_data.q).metpy.convert_units('degK')
+    dp2 = wet_bulb_temperature(test_data.level, test_data.t, dp) * units.degK
 
-    wbt = wet_bulb_temperature(test_data.level, test_data.t, dp)
-
-    print(wbt)
+    assert_allclose(dp, dp2)
 

--- a/test_front.py
+++ b/test_front.py
@@ -3,6 +3,9 @@ import json
 import xarray as xr
 import numpy as np
 
+from metpy.calc import wet_bulb_temperature, dewpoint_from_specific_humidity
+from metpy.units import units
+
 def test_front_detection():
 
     test_data = xr.open_dataset('tests/front_test.nc')
@@ -22,3 +25,26 @@ def test_front_detection():
         sample = json.load(sample_file)
 
         assert frontdata == sample
+
+def test_dewpoint():
+
+    test_data = xr.open_dataset('tests/front_test.nc')#.metpy.quantify()
+
+    dp = dewpoint_from_specific_humidity(test_data.level, test_data.t, test_data.q)
+
+    print(dp)
+    dp2 = fronts.dewpoint(test_data.t, test_data.q, test_data.level, ta_units=str(test_data.t.metpy.units)) * units.degK
+
+    import pdb; pdb.set_trace()
+    assert dp == dp2
+
+def test_wetbulb():
+
+    test_data = xr.open_dataset('tests/front_test.nc').metpy.quantify()
+
+    dp = dewpoint_from_specific_humidity(test_data.level, test_data.t, test_data.q)
+
+    wbt = wet_bulb_temperature(test_data.level, test_data.t, dp)
+
+    print(wbt)
+

--- a/test_front.py
+++ b/test_front.py
@@ -2,6 +2,7 @@ import fronts
 import json
 import xarray as xr
 import numpy as np
+from xarray.testing import assert_allclose
 
 from metpy.calc import wet_bulb_temperature, dewpoint_from_specific_humidity
 from metpy.units import units
@@ -36,7 +37,7 @@ def test_dewpoint():
     dp2 = fronts.dewpoint(test_data.t, test_data.q, test_data.level, ta_units=str(test_data.t.metpy.units)) * units.degK
 
     # import pdb; pdb.set_trace()
-    assert dp == dp2
+    assert_allclose(dp, dp2)
 
 def test_wetbulb():
 

--- a/test_front.py
+++ b/test_front.py
@@ -35,7 +35,7 @@ def test_dewpoint():
     print(dp)
     dp2 = fronts.dewpoint(test_data.t, test_data.q, test_data.level, ta_units=str(test_data.t.metpy.units)) * units.degK
 
-    import pdb; pdb.set_trace()
+    # import pdb; pdb.set_trace()
     assert dp == dp2
 
 def test_wetbulb():

--- a/test_front.py
+++ b/test_front.py
@@ -16,9 +16,17 @@ def test_front_detection():
     va = test_data.v
     hus = test_data.q
     
-    t_wet=fronts.wetbulb(ta,hus,900,steps=120)
+    t_wet = fronts.wetbulb(ta,
+                           hus,
+                           900,
+                           steps=120)
     
-    frontdata=fronts.front(t_wet,ua,va,threshold_i=-1e-10,numsmooth=9,minlength=50)
+    frontdata = fronts.front(t_wet,
+                             ua,
+                             va,
+                             threshold_i=-1e-10,
+                             numsmooth=9,
+                             minlength=50)
     
     timestring=np.datetime_as_string(test_data.time.data,unit='h')
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ numpy
 xarray
 scipy
 geopy
+metpy

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,4 @@ xarray
 scipy
 geopy
 metpy
+netcdf4


### PR DESCRIPTION
Rather than refactoring and testing all Malcolm's code, this is the start of the process of substituting in well tested and supported [metpy](https://unidata.github.io/MetPy/latest/index.html) routines.

This also has the benefit of reducing the supported code base, focussing the effort on what is unique and novel.